### PR TITLE
Fixed dot env dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": ">=5.4.0",
     "davispeixoto/force-dot-com-toolkit-for-php": "1.0.*",
     "illuminate/support": "~5.0",
-    "vlucas/phpdotenv": "~1.0"
+    "vlucas/phpdotenv": "~2.2"
   },
   "require-dev": {
     "laravel/framework": "~5.0",


### PR DESCRIPTION
This fixes the dot env composer version for laravel 5.2.

Minor change but thought I'd send it over.
